### PR TITLE
Update example.json and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,12 @@ current state here:
 [https://grizzly-pass.surge.sh](https://grizzly-pass.surge.sh)
 
 If you drag drop a correctly formatted json file onto the page (you can find one
-[here](./example/example.json)) then it will display those projects.
+[here](./example/example.json)) then it will display those projects. Valid project
+fields are:
+
+- title (required, string)
+- person (required, string)
+- date (required, string in YYYY-MM-DD format)
+- progress (required, number representing a percentage)
+- health (required, one of "ontrack", "atrisk", "intervention" or "onhold")
+- tags (optional, array of strings to be used as free-form tags on projects)

--- a/example/example.json
+++ b/example/example.json
@@ -1,38 +1,23 @@
-{
-  "title": "Demo Dashboard",
-  "projects": [
-    {
-      "id": "1",
-      "title": "Coffee Swirl",
-      "person": "Joe Lemon",
-      "time": "2017-03-15T10:54:04.445Z",
-      "progress": 13,
-      "status": "ontrack",
-      "labels": [
-        "3"
-      ]
-    },
-    {
-      "id": "2",
-      "title": "Rake Twister",
-      "person": "Alex Apple",
-      "time": "2017-04-12T10:54:04.445Z",
-      "progress": 50,
-      "status": "onhold",
-      "labels": [
-        "3",
-        "4"
-      ]
-    }
-  ],
-  "labels": [
-    {
-      "id": "3",
-      "title": "Apple"
-    },
-    {
-      "id": "4",
-      "title": "Orange"
-    }
-  ]
-}
+[
+  {
+    "title": "Coffee Swirl",
+    "person": "Joe Lemon",
+    "date": "2017-03-15",
+    "progress": 13,
+    "health": "ontrack",
+    "tags": [
+      "Apple"
+    ]
+  },
+  {
+    "title": "Rake Twister",
+    "person": "Alex Apple",
+    "date": "2017-04-12",
+    "progress": 50,
+    "health": "onhold",
+    "tags": [
+      "Apple",
+      "Orange"
+    ]
+  }
+]


### PR DESCRIPTION
The documentation got stale while working on the new import format. The old format (which matched the internal layout) was a bit hard for humans to right I feel.

Fixes #1